### PR TITLE
Fix eventemitter saturation by winston

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run:
+          name: Install
+          command: yarn
+      - run:
           name: Bootstrap
           command: yarn run bootstrap
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,11 @@ jobs:
           name: Bootstrap
           command: yarn run bootstrap
       - run:
-          name: Lint
-          command: yarn run lint
-      - run:
           name: Build
           command: yarn run build
+      - run:
+          name: Lint
+          command: yarn run lint
       - run:
           name: Test
           command: yarn run test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "lerna run clean && rm -r node_modules",
     "lint": "lerna run lint",
     "test": "yarn run test:unit && yarn run test:integration",
-    "test:integration": "jest \"(src\\/.+\\.|/)winston.integration\\.ts$\"",
+    "test:integration": "jest \"(src\\/.+\\.|/)integration\\.ts$\"",
     "test:integration:watch": "yarn run test:integration --watch",
     "test:unit": "jest \"(src\\/.+\\.|/)spec\\.ts$\"",
     "test:unit:watch": "yarn run test:unit --watch"

--- a/packages/logger-core/src/bind-logger.ts
+++ b/packages/logger-core/src/bind-logger.ts
@@ -1,4 +1,3 @@
-import { Logger } from './logger'
 import { interfaces } from 'inversify'
 import { LOGGER_SYMBOLS } from './logger-symbols'
 import { LoggerFactory } from './logger-factory'
@@ -12,7 +11,7 @@ export type ClassConstructor<Type> = new (...args: any[]) => Type
  * @param type Type the logger is being bound to
  */
 export function bindLogger<T> (bind: interfaces.Bind, type: ClassConstructor<T>): void {
-  bind<Logger>(LOGGER_SYMBOLS.Logger)
+  bind(LOGGER_SYMBOLS.Logger)
     .toDynamicValue(context => {
       const factory = context.container.get<LoggerFactory>(LOGGER_SYMBOLS.LoggerFactory)
       return factory.build(type.name, context.container)

--- a/packages/logger-core/src/console-logger.spec.ts
+++ b/packages/logger-core/src/console-logger.spec.ts
@@ -27,7 +27,7 @@ describe('ConsoleLogger', () => {
     )
   })
 
-  it('should log trace to debug', () => {
+  it('should log trace to trace', () => {
     sut.trace(message, data)
     jsConsole.verify(
       c => c.trace(expectedMessage, data),

--- a/packages/logger-core/src/console-logger.ts
+++ b/packages/logger-core/src/console-logger.ts
@@ -22,7 +22,7 @@ export class ConsoleLogger implements Logger {
 
   trace (message: string, data?: object): void {
     // tslint:disable-next-line:no-unsafe-any Node typings
-    log(this.jsConsole.debug.bind(this), this.name, message, data)
+    log(this.jsConsole.trace.bind(this), this.name, message, data)
   }
 
   info (message: string, data?: object): void {

--- a/packages/logger-winston/src/winston-configuration.ts
+++ b/packages/logger-winston/src/winston-configuration.ts
@@ -2,7 +2,7 @@ import { injectable } from 'inversify'
 import winston, { format, transports } from 'winston'
 
 export interface WinstonConfiguration {
-  getConfiguration (loggerName: string): winston.LoggerOptions
+  getConfiguration (): winston.LoggerOptions
 }
 
 const consoleTransport = new transports.Console({
@@ -22,9 +22,8 @@ const errorStackFormat = format(info => {
 
 @injectable()
 export class DefaultWinstonConfiguration implements WinstonConfiguration {
-  getConfiguration (loggerName: string): winston.LoggerOptions {
+  getConfiguration (): winston.LoggerOptions {
     return {
-      defaultMeta: { loggerName },
       transports: [consoleTransport],
       format: format.combine(
         format.timestamp(),

--- a/packages/logger-winston/src/winston-internal-symbols.ts
+++ b/packages/logger-winston/src/winston-internal-symbols.ts
@@ -1,0 +1,3 @@
+export const WINSTON_INTERNAL_SYMBOLS = {
+  WinstonInstance: Symbol.for('node-ts/logger/winston/winston-instance')
+}

--- a/packages/logger-winston/src/winston-logger-factory.ts
+++ b/packages/logger-winston/src/winston-logger-factory.ts
@@ -1,16 +1,13 @@
 import { LoggerFactory, Logger } from '@node-ts/logger-core'
 import { interfaces, injectable } from 'inversify'
-import { createLogger } from 'winston'
 import { WinstonLogger } from './winston-logger'
-import { WinstonConfiguration } from './winston-configuration'
-import { WINSTON_SYMBOLS } from './winston-symbols'
+import { WINSTON_INTERNAL_SYMBOLS } from './winston-internal-symbols'
+import { Logger as WinstonInstance } from 'winston'
 
 @injectable()
 export class WinstonLoggerFactory implements LoggerFactory {
   build (loggerName: string, container: interfaces.Container): Logger {
-    const configurer = container.get<WinstonConfiguration>(WINSTON_SYMBOLS.WinstonConfiguration)
-    const configuration = configurer.getConfiguration(loggerName)
-    const winstonLogger = createLogger(configuration)
-    return new WinstonLogger(winstonLogger)
+    const winstonLogger = container.get<WinstonInstance>(WINSTON_INTERNAL_SYMBOLS.WinstonInstance)
+    return new WinstonLogger(loggerName, winstonLogger)
   }
 }

--- a/packages/logger-winston/src/winston-logger.integration.ts
+++ b/packages/logger-winston/src/winston-logger.integration.ts
@@ -1,5 +1,5 @@
 // tslint:disable:max-classes-per-file no-unbound-method no-unsafe-any no-any
-import { Container, decorate, injectable, inject } from 'inversify'
+import { Container, decorate, injectable, inject, interfaces } from 'inversify'
 import { WinstonModule } from './winston-module'
 import { LoggerModule, bindLogger, LOGGER_SYMBOLS, Logger } from '@node-ts/logger-core'
 
@@ -17,7 +17,8 @@ class TargetK { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {
 class TargetL { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
 class TargetM { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
 
-const classes = [
+// tslint:disable-next-line:no-any
+const classes: interfaces.Newable<any>[] = [
  TargetA,
  TargetB,
  TargetC,

--- a/packages/logger-winston/src/winston-logger.integration.ts
+++ b/packages/logger-winston/src/winston-logger.integration.ts
@@ -1,0 +1,56 @@
+// tslint:disable:max-classes-per-file no-unbound-method no-unsafe-any no-any
+import { Container, decorate, injectable, inject } from 'inversify'
+import { WinstonModule } from './winston-module'
+import { LoggerModule, bindLogger, LOGGER_SYMBOLS, Logger } from '@node-ts/logger-core'
+
+class TargetA { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetB { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetC { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetD { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetE { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetF { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetG { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetH { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetI { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetJ { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetK { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetL { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetM { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+
+const classes = [
+ TargetA,
+ TargetB,
+ TargetC,
+ TargetD,
+ TargetE,
+ TargetF,
+ TargetG,
+ TargetH,
+ TargetI,
+ TargetJ,
+ TargetK,
+ TargetL,
+ TargetM
+]
+
+describe('WinstonLogger', () => {
+  describe('when resolving multiple loggers', () => {
+    beforeAll(async () => {
+      const container = new Container()
+      container.load(new LoggerModule())
+      container.load(new WinstonModule())
+
+      classes.forEach(c => {
+        decorate(injectable(), c)
+        container.bind(c).to(c)
+        bindLogger((id: any) => container.bind(id), c)
+      })
+      classes.forEach(c => container.get(c))
+    })
+
+    it('should not warn about event emitters', () => {
+      // Short of capturing STDOUT, just manually checking to see that no warnings are thrown to console
+      expect(true).toBeTruthy()
+    })
+  })
+})

--- a/packages/logger-winston/src/winston-logger.integration.ts
+++ b/packages/logger-winston/src/winston-logger.integration.ts
@@ -3,19 +3,19 @@ import { Container, decorate, injectable, inject } from 'inversify'
 import { WinstonModule } from './winston-module'
 import { LoggerModule, bindLogger, LOGGER_SYMBOLS, Logger } from '@node-ts/logger-core'
 
-class TargetA { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetB { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetC { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetD { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetE { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetF { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetG { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetH { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetI { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetJ { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetK { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetL { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
-class TargetM { constructor (@inject(LOGGER_SYMBOLS.Logger) _: Logger) {} }
+class TargetA { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetB { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetC { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetD { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetE { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetF { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetG { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetH { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetI { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetJ { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetK { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetL { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
+class TargetM { constructor (@inject(LOGGER_SYMBOLS.Logger) private _: Logger) {} }
 
 const classes = [
  TargetA,

--- a/packages/logger-winston/src/winston-logger.spec.ts
+++ b/packages/logger-winston/src/winston-logger.spec.ts
@@ -1,5 +1,5 @@
 import { WinstonLogger } from './winston-logger'
-import { IMock, Mock, Times } from 'typemoq'
+import { IMock, Mock, Times, It } from 'typemoq'
 import winston from 'winston'
 
 describe('winston-logger', () => {
@@ -8,11 +8,14 @@ describe('winston-logger', () => {
   let winstonLogger: IMock<winston.Logger>
 
   const message = 'log message'
-  const data = {}
+  const name = 'winston-spec'
+  const data = { a: 'b', c: 1 }
+  const meta = { name, ...data }
 
   beforeEach(() => {
     winstonLogger = Mock.ofType<winston.Logger>()
     sut = new WinstonLogger(
+      name,
       winstonLogger.object
     )
   })
@@ -20,7 +23,7 @@ describe('winston-logger', () => {
   it('should log debug to debug', () => {
     sut.debug(message, data)
     winstonLogger.verify(
-      w => w.debug(message, data),
+      w => w.debug(message, It.isObjectWith(meta)),
       Times.once()
     )
   })
@@ -28,7 +31,7 @@ describe('winston-logger', () => {
   it('should log trace to verbose', () => {
     sut.trace(message, data)
     winstonLogger.verify(
-      w => w.verbose(message, data),
+      w => w.verbose(message, It.isObjectWith(meta)),
       Times.once()
     )
   })
@@ -36,7 +39,7 @@ describe('winston-logger', () => {
   it('should log info to info', () => {
     sut.info(message, data)
     winstonLogger.verify(
-      w => w.info(message, data),
+      w => w.info(message, It.isObjectWith(meta)),
       Times.once()
     )
   })
@@ -44,7 +47,7 @@ describe('winston-logger', () => {
   it('should log warn to warn', () => {
     sut.warn(message, data)
     winstonLogger.verify(
-      w => w.warn(message, data),
+      w => w.warn(message, It.isObjectWith(meta)),
       Times.once()
     )
   })
@@ -52,7 +55,7 @@ describe('winston-logger', () => {
   it('should log error to error', () => {
     sut.error(message, data)
     winstonLogger.verify(
-      w => w.error(message, data),
+      w => w.error(message, It.isObjectWith(meta)),
       Times.once()
     )
   })
@@ -60,7 +63,7 @@ describe('winston-logger', () => {
   it('should log fatal to crit', () => {
     sut.fatal(message, data)
     winstonLogger.verify(
-      w => w.crit(message, data),
+      w => w.crit(message, It.isObjectWith(meta)),
       Times.once()
     )
   })

--- a/packages/logger-winston/src/winston-logger.ts
+++ b/packages/logger-winston/src/winston-logger.ts
@@ -6,45 +6,50 @@ import autobind from 'autobind-decorator'
 export class WinstonLogger implements Logger  {
 
   constructor (
+    private readonly name: string,
     private readonly winstonLogger: winston.Logger = winston.createLogger()
   ) {
   }
 
   debug (message: string, data?: object): void {
-    log(this.winstonLogger.debug, message, data)
+    log(this.winstonLogger.debug, message, this.name, data)
   }
 
   trace (message: string, data?: object): void {
-    log(this.winstonLogger.verbose, message, data)
+    log(this.winstonLogger.verbose, message, this.name, data)
   }
 
   info (message: string, data?: object): void {
-    log(this.winstonLogger.info, message, data)
+    log(this.winstonLogger.info, message, this.name, data)
   }
 
   warn (message: string, data?: object): void {
-    log(this.winstonLogger.warn, message, data)
+    log(this.winstonLogger.warn, message, this.name, data)
   }
 
   error (message: string, data?: object): void {
-    log(this.winstonLogger.error, message, data)
+    log(this.winstonLogger.error, message, this.name, data)
   }
 
   fatal (message: string, data?: object): void {
-    log(this.winstonLogger.crit, message, data)
+    log(this.winstonLogger.crit, message, this.name, data)
   }
-
 }
 
 function log (
   // tslint:disable:no-any Node typings
   logFn: (message: string, ...optionalParams: any[]) => void,
   message: string,
+  name: string,
   data?: object
 ): void {
-  if (data) {
-    logFn(message, data)
-  } else {
-    logFn(message)
+  const meta = merge(name, data)
+  logFn(message, meta)
+}
+
+function merge (name: string, meta: object | undefined): object {
+  return {
+    name,
+    ...meta
   }
 }

--- a/packages/logger-winston/src/winston-module.ts
+++ b/packages/logger-winston/src/winston-module.ts
@@ -2,13 +2,24 @@ import { ContainerModule } from 'inversify'
 import { LOGGER_SYMBOLS } from '@node-ts/logger-core'
 import { WinstonLoggerFactory } from './winston-logger-factory'
 import { WINSTON_SYMBOLS } from './winston-symbols'
-import { DefaultWinstonConfiguration } from './winston-configuration'
+import { DefaultWinstonConfiguration, WinstonConfiguration } from './winston-configuration'
+import { WINSTON_INTERNAL_SYMBOLS } from './winston-internal-symbols'
+import { createLogger } from 'winston'
 
 export class WinstonModule extends ContainerModule {
   constructor () {
     super((bind, _, __, rebind) => {
       bind(WINSTON_SYMBOLS.WinstonConfiguration).to(DefaultWinstonConfiguration)
       rebind(LOGGER_SYMBOLS.LoggerFactory).to(WinstonLoggerFactory)
+
+      // We want a singleton instance of Winston - otherwise it floods the app with event emitters
+      bind(WINSTON_INTERNAL_SYMBOLS.WinstonInstance)
+        .toDynamicValue(context => {
+          const configurer = context.container.get<WinstonConfiguration>(WINSTON_SYMBOLS.WinstonConfiguration)
+          const configuration = configurer.getConfiguration()
+          return createLogger(configuration)
+        })
+        .inSingletonScope()
     })
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
     "lib": ["es2017", "dom"],
     "paths": {
       "@node-ts/*": ["./*/src"]
-    }
+    },
+    // Handled in linting, useful for testing
+    "allowUnreachableCode": true,
+    "noUnusedLocals": false
   }
 }


### PR DESCRIPTION
Winston adds eventemitters for every instance created by `createLogger`. This eventually throws a node warning showing emitter saturation.

This PR creates a single Winston instance, and then wraps a proxy around it for each logger instance; thereby achieving transient lifecycle of the logger, but a singleton of the winston logger itself.